### PR TITLE
Removing ability for megafauna to round remove people.

### DIFF
--- a/code/datums/actions/mobs/lava_swoop.dm
+++ b/code/datums/actions/mobs/lava_swoop.dm
@@ -98,9 +98,11 @@
 	playsound(owner.loc, 'sound/effects/meteorimpact.ogg', 200, TRUE)
 	for(var/mob/living/L in orange(1, owner) - owner)
 		if(L.stat)
+		/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 			owner.visible_message(span_warning("[owner] slams down on [L], crushing [L.p_them()]!"))
 			L.gib()
 		else
+		*/ //ACULASTATION EDIT END
 			L.adjustBruteLoss(75)
 			if(L && !QDELETED(L)) // Some mobs are deleted on death
 				var/throw_dir = get_dir(owner, L)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -13,7 +13,7 @@
 	weather_immunities = list(TRAIT_LAVA_IMMUNE,TRAIT_ASHSTORM_IMMUNE)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
-	stat_attack = DEAD
+	stat_attack = HARD_CRIT //ACULASTATION EDIT - Remove megafauna gibbing: This makes megafauna not attack corpses.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	damage_coeff = list(BRUTE = 1, BURN = 0.5, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	minbodytemp = 0
@@ -126,10 +126,12 @@
 			if(!client && ranged && ranged_cooldown <= world.time)
 				OpenFire()
 
+		/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH)) //Nope, it still gibs yall
 				devour(L)
 		else
 			devour(L)
+		*/ //ACULASTATION EDIT END
 
 /// Devours a target and restores health to the megafauna
 /mob/living/simple_animal/hostile/megafauna/proc/devour(mob/living/L)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -129,6 +129,7 @@ Difficulty: Medium
 	if(QDELETED(target))
 		return
 	face_atom(target)
+	/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 	if(isliving(target))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -141,6 +142,7 @@ Difficulty: Medium
 					adjustHealth(-(L.maxHealth * 0.5))
 			L.gib()
 			return TRUE
+		*/ //ACULASTATION EDIT END
 	changeNext_move(CLICK_CD_MELEE)
 	miner_saw.melee_attack_chain(src, target)
 	if(guidance)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -214,6 +214,7 @@ Difficulty: Hard
 		new /obj/effect/temp_visual/bubblegum_hands/leftpaw(T)
 		new /obj/effect/temp_visual/bubblegum_hands/leftthumb(T)
 	SLEEP_CHECK_DEATH(6, src)
+	/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 	for(var/mob/living/L in T)
 		if(!faction_check_mob(L))
 			if(L.stat != CONSCIOUS)
@@ -224,6 +225,7 @@ Difficulty: Hard
 				playsound(targetturf, 'sound/magic/exit_blood.ogg', 100, TRUE, -1)
 				addtimer(CALLBACK(src, .proc/devour, L), 2)
 	SLEEP_CHECK_DEATH(1, src)
+	*/ //ACULASTATION EDIT END
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -144,9 +144,11 @@
 		if (is_species(H, /datum/species/golem/sand))
 			. = TRUE
 
+/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 /mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/L)
 	visible_message(span_colossus("[src] disintegrates [L]!"))
 	L.dust()
+*/ //ACULASTATION EDIT END
 
 /obj/effect/temp_visual/at_shield
 	name = "anti-toolbox field"
@@ -184,11 +186,13 @@
 
 /obj/projectile/colossus/on_hit(atom/target, blocked = FALSE)
 	. = ..()
+	/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 	if(isliving(target))
 		var/mob/living/dust_mob = target
 		if(dust_mob.stat == DEAD)
 			dust_mob.dust()
 		return
+	*/ //ACULASTATION EDIT END
 	if(!explode_hit_objects || istype(target, /obj/vehicle/sealed))
 		return
 	if(isturf(target) || isobj(target))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -429,6 +429,7 @@ Difficulty: Hard
 		set_stat(CONSCIOUS) // deathgasp won't run if dead, stupid
 		..(force_grant = stored_nearby)
 
+/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 /mob/living/simple_animal/hostile/megafauna/hierophant/devour(mob/living/L)
 	for(var/obj/item/W in L)
 		if(!L.dropItemToGround(W))
@@ -437,6 +438,7 @@ Difficulty: Hard
 	visible_message(span_hierophant_warning("[src] annihilates [L]!"),span_userdanger("You annihilate [L], restoring your health!"))
 	adjustHealth(-L.maxHealth*0.5)
 	L.dust()
+*/ //ACULASTATION EDIT END
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/CanAttack(atom/the_target)
 	. = ..()
@@ -470,8 +472,10 @@ Difficulty: Hard
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
 				OpenFire()
+			/* //ACULASTATION EDIT START - Remove megafauna gibbing.
 			else
 				devour(L)
+			*/ //ACULASTATION EDIT END
 		else
 			return ..()
 


### PR DESCRIPTION
## About The Pull Request

Removes the ability for megafauna to gib or dust people by commenting out relevant code. 

Also makes megafauna only target living players by changing "stat_attack" from DEAD to HARD_CRIT. If I didn't do this then megafauna would attack player corpses forever.

## Why It's Good For The Game

Megafauna gibbing or dusting dead players effectively removes them from the round. Round removal by mobs sucks for players, especially in our current lowpop state. It'll still be difficult to recover players killed by megafauna since they'll still likely be hanging around the area and due to massive injuries incurred by them, but it won't be (borderline) impossible anymore.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Megafauna can no longer gib nor dust players.
/:cl:
