### PR TITLE
Fix hole to space in Tramstation's security.

### DIFF
--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -23118,19 +23118,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"gtB" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},/* //ACULASTATION EDIT START - HORNY REMOVAL
-/obj/machinery/vending/dorms{
-	contraband = list(/obj/item/electropack/shockcollar = 4, /obj/item/clothing/neck/kink_collar/locked = 4, /obj/item/clothing/neck/mind_collar = 2, /obj/item/clothing/under/costume/jabroni = 4, /obj/item/clothing/neck/human_petcollar/locked = 4, /obj/item/assembly/signaler = 0, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag = 0, /obj/item/reagent_containers/pill/hexacrocin = 10, /obj/item/reagent_containers/pill/pentacamphor = 5, /obj/item/reagent_containers/glass/bottle/hexacrocin = 4, /obj/item/reagent_containers/glass/bottle/pentacamphor = 2);
-	desc = "A vending machine with various toys. Not for the faint of heart. This one seems to have a reduced inventory.";
-	name = "NanoTrasen Approved LustWish";
-	payment_department = "SEC";
-	products = list(/obj/item/clothing/sextoy/signalvib = 8, /obj/item/assembly/signaler = 0, /obj/item/clothing/sextoy/eggvib = 8, /obj/item/clothing/sextoy/buttplug = 6, /obj/item/clothing/sextoy/nipple_clamps = 4, /obj/item/clothing/sextoy/double_dildo = 3, /obj/item/clothing/sextoy/vibroring = 6, /obj/item/condom_pack = 20, /obj/item/clothing/sextoy/dildo = 8, /obj/item/clothing/sextoy/custom_dildo = 8, /obj/item/tickle_feather = 8, /obj/item/clothing/sextoy/fleshlight = 8, /obj/item/kinky_shocker = 4, /obj/item/clothing/mask/leatherwhip = 4, /obj/item/clothing/sextoy/magic_wand = 4, /obj/item/bdsm_candle = 4, /obj/item/spanking_pad = 4, /obj/item/clothing/sextoy/vibrator = 4, /obj/item/serviette_pack = 10, /obj/item/restraints/handcuffs/lewd = 0, /obj/item/key/collar = 48, /obj/item/pillow = 32, /obj/item/clothing/mask/ballgag = 8, /obj/item/clothing/mask/ballgag/choking = 8, /obj/item/clothing/mask/muzzle/ring = 4, /obj/item/clothing/head/domina_cap = 5, /obj/item/clothing/head/helmet/space/deprivation_helmet = 5, /obj/item/clothing/head/maid = 5, /obj/item/clothing/glasses/blindfold/kinky = 5, /obj/item/clothing/ears/kinky_headphones = 5, /obj/item/clothing/mask/gas/bdsm_mask = 5, /obj/item/reagent_containers/glass/lewd_filter = 5, /obj/item/clothing/glasses/hypno = 4, /obj/item/clothing/head/kitty = 4, /obj/item/clothing/head/rabbitears = 4, /obj/item/clothing/neck/kink_collar = 8, /obj/item/clothing/neck/human_petcollar = 8, /obj/item/clothing/neck/human_petcollar/choker = 8, /obj/item/clothing/neck/human_petcollar/locked/cow = 8, /obj/item/clothing/neck/human_petcollar/locked/bell = 8, /obj/item/clothing/neck/human_petcollar/locked/cross = 8, /obj/item/clothing/neck/human_petcollar/locked/spike = 8, /obj/item/clothing/under/misc/latex_catsuit = 8, /obj/item/clothing/suit/straight_jacket/latex_straight_jacket = 0, /obj/item/clothing/under/costume/maid = 5, /obj/item/clothing/under/rank/civilian/janitor/maid = 5, /obj/item/clothing/under/costume/lewdmaid = 5, /obj/item/clothing/suit/straight_jacket/shackles = 0, /obj/item/clothing/under/stripper_outfit = 5, /obj/item/clothing/under/misc/stripper/bunnysuit = 5, /obj/item/clothing/under/misc/stripper/bunnysuit/white = 5, /obj/item/clothing/under/misc/gear_harness = 4, /obj/item/clothing/gloves/ball_mittens = 8, /obj/item/clothing/gloves/latex_gloves = 8, /obj/item/clothing/gloves/evening = 5, /obj/item/clothing/shoes/latex_socks = 8, /obj/item/clothing/shoes/latexheels = 4, /obj/item/clothing/shoes/dominaheels = 4, /obj/item/clothing/shoes/jackboots/thigh = 3, /obj/item/clothing/shoes/jackboots/knee = 3, /obj/item/clothing/strapon = 6, /obj/item/storage/belt/erpbelt = 5, /obj/item/reagent_containers/pill/crocin = 20, /obj/item/reagent_containers/pill/camphor = 10, /obj/item/reagent_containers/glass/bottle/crocin = 6, /obj/item/reagent_containers/glass/bottle/camphor = 3, /obj/item/reagent_containers/glass/bottle/breast_enlarger = 6, /obj/item/reagent_containers/glass/bottle/penis_enlarger = 6, /obj/item/clothing/glasses/nice_goggles = 1, /obj/item/storage/box/bdsmbed_kit = 0, /obj/item/storage/box/strippole_kit = 0, /obj/item/storage/box/xstand_kit = 0, /obj/item/storage/box/milking_kit = 0)
-	},*/ //ACULASTATION EDIT END
-/turf/open/floor/iron,
-/area/security/prison)
 "gtJ" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /obj/machinery/button/door{
@@ -92335,7 +92322,7 @@ htN
 ccM
 ccM
 ccM
-gtB
+uXd
 qKe
 jbD
 fnk


### PR DESCRIPTION
## About The Pull Request

Title. Fixes a hole to space in Tramstation's security created by removing a varedited ERP vending machine.

## Why It's Good For The Game

Having holes to space that vent the atmospheres of places players are supposed to spawn in is bad.

## Changelog

:cl:
fix: There is no longer a hole to space in Tramstation's security.
/:cl:

