### PR TITLE
Insulated gloves no longer give you chunky fingers.

### DIFF
--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5374,6 +5374,7 @@
 #include "modular_skyrat\modules\xenoarch\code\modules\research\xenoarch\xenoarch_machine.dm"
 #include "modular_skyrat\modules\xenoarch\code\modules\research\xenoarch\xenoarch_reward.dm"
 #include "modular_skyrat\modules\xenoarch\code\modules\research\xenoarch\xenoarch_tool.dm"
+#include "z__modular_aculastation\modules\insultweak\color.dm"
 #include "z__modular_aculastation\modules\no_horny\feather.dm"
 #include "z__modular_aculastation\modules\no_horny\helper_procs.dm"
 #include "z__modular_aculastation\modules\no_horny\qdel_horny.dm"

--- a/z__modular_aculastation/modules/insultweak/color.dm
+++ b/z__modular_aculastation/modules/insultweak/color.dm
@@ -1,3 +1,3 @@
 //This file overrides the CHUNKYFINGERS trait on the insulated gloves to make them usable with guns and consoles.
 /obj/item/clothing/gloves/color/yellow
-	clothing_traits = list(NONE)
+	clothing_traits = list() //Leaving nothing between the parenthesees makes the list empty.

--- a/z__modular_aculastation/modules/insultweak/color.dm
+++ b/z__modular_aculastation/modules/insultweak/color.dm
@@ -1,0 +1,3 @@
+//This file overrides the CHUNKYFINGERS trait on the insulated gloves to make them usable with guns and consoles.
+/obj/item/clothing/gloves/color/yellow
+	clothing_traits = list(NONE)


### PR DESCRIPTION
## About The Pull Request

Title. This PR removes the chunky fingers trait from insulated gloves, meaning they no longer stop you from using consoles or guns when equipped.

## Why It's Good For The Game

The presence of the chunky fingers trait on insulated gloves didn't add anything to the game, it only made it annoying to use consoles, tablets, and guns while also having insulated gloves on your hands. All you had to do was take the gloves off anyways, which isn't really fun obviously.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed chunky fingers trait for insulated gloves, allowing them to be used with guns and consoles again.
/:cl:
